### PR TITLE
PP-12937: Change final resource image to use an alpine base

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,24 @@
+name: Post Merge
+
+on:
+  push:
+    branches:
+      - "main"
+    paths-ignore:
+      - '.github/**'
+
+permissions:
+  contents: read
+
+concurrency: cron-resource-post-merge
+
+jobs:
+  tests:
+    uses: ./.github/workflows/_run-tests.yml
+
+  tag-release:
+    needs:
+      - tests
+    permissions:
+      contents: write
+    uses: alphagov/pay-ci/.github/workflows/_create-alpha-release-tag.yml@main`

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ COPY . /resource
 WORKDIR /resource
 RUN ./build.sh
 
-FROM ubuntu:bionic
+FROM alpine:3.20.1@sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a0c4394e0
 COPY --from=resource /resource/tmp/build/* /opt/resource/
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y tzdata && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache tzdata

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Update your pipeline to include this new declaration of resource types. See the 
 ---
 resource_types:
 - name: cron-resource
-  type: docker-image
+  type: registry-image
   source:
-    repository: cftoolsmiths/cron-resource
+    repository: governmentdigitalservice/pay-cron-resource
 
 resources:
   - name: 10-min-trigger


### PR DESCRIPTION
1. Change final built image to use alpine base, and with a SHA pin now we are up to date.
2. Add a post-merge workflow which tests and creates release tags now we are happy everything is up to date
3.  Update the README with the correct dockerhub repo for our fork