### PR TITLE
PP-12937: udpate pay-ci branch to main from master

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -21,4 +21,4 @@ jobs:
       - tests
     permissions:
       contents: write
-    uses: alphagov/pay-ci/.github/workflows/_create-alpha-release-tag.yml@main`
+    uses: alphagov/pay-ci/.github/workflows/_create-alpha-release-tag.yml@master`

--- a/README.md
+++ b/README.md
@@ -91,3 +91,4 @@ $ echo '{"source":{"expression":"* * * * *","location":"America/New_York"}}' \
 ## Vulnerability Disclosure
 
 GOV.UK Pay aims to stay secure for everyone. If you are a security researcher and have discovered a security vulnerability in this code, we appreciate your help in disclosing it to us in a responsible manner. Please refer to our [vulnerability disclosure policy](https://www.gov.uk/help/report-vulnerability) and our [security.txt](https://vdp.cabinetoffice.gov.uk/.well-known/security.txt) file for details.
+


### PR DESCRIPTION
The post-merge workflow needs to reference master in pay-ci, not main