### PR TITLE
PP-12937: Convert final image to a scratch container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,5 @@ COPY . /resource
 WORKDIR /resource
 RUN ./build.sh
 
-FROM alpine:3.20.1@sha256:b89d9c93e9ed3597455c90a0b88a8bbb5cb7188438f70953fede212a0c4394e0
+FROM scratch
 COPY --from=resource /resource/tmp/build/* /opt/resource/
-RUN apk add --no-cache tzdata

--- a/build.sh
+++ b/build.sh
@@ -14,5 +14,5 @@ ginkgo -r .
 
 mkdir -p tmp/build
 
-go build -o tmp/build/in in/main.go
-go build -o tmp/build/check check/check.go
+CGO_ENABLED=0 GOOS=linux go build -o tmp/build/in in/main.go
+CGO_ENABLED=0 GOOS=linux go build -o tmp/build/check check/check.go

--- a/check/check.go
+++ b/check/check.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/mbrevoort/cronexpr"
 	"github.com/pivotal-cf-experimental/cron-resource/models"

--- a/in/main.go
+++ b/in/main.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	_ "time/tzdata"
 
 	"github.com/pivotal-cf-experimental/cron-resource/models"
 )


### PR DESCRIPTION
This is an experiment, before we are 100% relying on this resource, to see if a scratch container with static binaries will work as a resource in concourse. If it works we will leave it like this.

1. Import the time/tzdata package (and call its init function (this is the _ prefix before the package name)). This removes the need for system installed timezone data
2. Completely statically compile the binaries targeting linux
3. Change the final image to be `FROM scratch`

We have never tried a FROM scratch concourse resource before, if it doesn't work we will revert this PR and re-release.